### PR TITLE
Aligns the reagent bottles as they used to be, corrects an issue with filler image and the base bottle icon_state.

### DIFF
--- a/code/modules/reagents/reagent_containers/bottle.dm
+++ b/code/modules/reagents/reagent_containers/bottle.dm
@@ -6,18 +6,12 @@
 	name = "bottle"
 	desc = "A small bottle."
 	icon = 'icons/obj/chemical.dmi'
-	icon_state = "rounded_bottle"
+	icon_state = "round_bottle"
 	item_state = "atoxinbottle"
 	amount_per_transfer_from_this = 10
 	possible_transfer_amounts = list(5,10,15,25,30)
 	flags = OPENCONTAINER
 	volume = 30
-
-/obj/item/weapon/reagent_containers/glass/bottle/New()
-	..()
-	if(!icon_state)
-		icon_state = pick("bottle", "small_bottle", "wide_bottle", "round_bottle")
-		update_icon()
 
 /obj/item/weapon/reagent_containers/glass/bottle/on_reagent_change()
 	update_icon()
@@ -27,7 +21,7 @@
 	underlays.Cut()
 
 	if(reagents.total_volume)
-		var/image/filling = image('icons/obj/reagentfillings.dmi', src, "bottle10")
+		var/image/filling = image('icons/obj/reagentfillings.dmi', src, "[icon_state]10")
 
 		var/percent = round((reagents.total_volume / volume) * 100)
 		switch(percent)
@@ -152,31 +146,41 @@
 	name = "Oil Bottle"
 	desc = "A reagent bottle. Contains oil."
 	list_reagents = list("oil" = 50)
+	pixel_x = -4
+	pixel_y = 6
 
 /obj/item/weapon/reagent_containers/glass/bottle/reagent/phenol
 	name = "Phenol Bottle"
 	desc = "A reagent bottle. Contains phenol."
 	list_reagents = list("phenol" = 50)
+	pixel_x = 6
+	pixel_y = 6
 
 /obj/item/weapon/reagent_containers/glass/bottle/reagent/acetone
 	name = "Acetone Bottle"
 	desc = "A reagent bottle. Contains acetone."
 	list_reagents = list("acetone" = 50)
+	pixel_x = -4
 
 /obj/item/weapon/reagent_containers/glass/bottle/reagent/ammonia
 	name = "Ammonia Bottle"
 	desc = "A reagent bottle. Contains ammonia."
 	list_reagents = list("ammonia" = 50)
+	pixel_x = 6
 
 /obj/item/weapon/reagent_containers/glass/bottle/reagent/diethylamine
 	name = "Diethylamine Bottle"
 	desc = "A reagent bottle. Contains diethylamine."
 	list_reagents = list("diethylamine" = 50)
+	pixel_x = -4
+	pixel_y = -6
 
 /obj/item/weapon/reagent_containers/glass/bottle/reagent/acid
 	name = "Acid Bottle"
 	desc = "A reagent bottle. Contains sulfuric acid."
 	list_reagents = list("sacid" = 50)
+	pixel_x = 6
+	pixel_y = -6
 
 /obj/item/weapon/reagent_containers/glass/bottle/reagent/formaldehyde
 	name = "Formaldehyde Bottle"


### PR DESCRIPTION
Takes care of all the issues Fox brought up but the underlays for https://github.com/ParadiseSS13/Paradise/pull/5551.

The reagent bottles in the chemistry locker are now positioned as they used to be via pixel_x and pixel_y, the values for which ascertained by comparing each rbottle# sprite to the original rbottle sprite
![bottlesstackingproperly](https://cloud.githubusercontent.com/assets/12377767/18194331/e0bb56b6-70b2-11e6-9186-9e7807b1525d.PNG)
